### PR TITLE
fix: shall re-throw errors on first connect

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -47,6 +47,7 @@ module.exports = app => {
 
 function createOneClient(config, app) {
   const { url, options } = config;
+  let isFirstConnect = true;
 
   assert(url, '[egg-mongoose] url is required on config');
 
@@ -58,6 +59,9 @@ function createOneClient(config, app) {
   db.on('error', err => {
     err.message = `[egg-mongoose]${err.message}`;
     app.coreLogger.error(err);
+    if (isFirstConnect) {
+      throw err;
+    }
   });
 
   /* istanbul ignore next */
@@ -67,6 +71,7 @@ function createOneClient(config, app) {
 
   db.on('connected', () => {
     app.coreLogger.info(`[egg-mongoose] ${url} connected successfully`);
+    isFirstConnect = false;
   });
 
   /* istanbul ignore next */

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -47,7 +47,6 @@ module.exports = app => {
 
 function createOneClient(config, app) {
   const { url, options } = config;
-  let isFirstConnect = true;
 
   assert(url, '[egg-mongoose] url is required on config');
 
@@ -59,9 +58,6 @@ function createOneClient(config, app) {
   db.on('error', err => {
     err.message = `[egg-mongoose]${err.message}`;
     app.coreLogger.error(err);
-    if (isFirstConnect) {
-      throw err;
-    }
   });
 
   /* istanbul ignore next */
@@ -71,7 +67,6 @@ function createOneClient(config, app) {
 
   db.on('connected', () => {
     app.coreLogger.info(`[egg-mongoose] ${url} connected successfully`);
-    isFirstConnect = false;
   });
 
   /* istanbul ignore next */
@@ -81,7 +76,10 @@ function createOneClient(config, app) {
 
   app.beforeStart(function* () {
     app.coreLogger.info('[egg-mongoose] starting...');
-    yield awaitEvent(db, 'connected');
+    yield Promise.race([
+      awaitEvent(db, 'connected'),
+      awaitEvent(db, 'error'),
+    ]);
     const index = count++;
     /*
      *remove heartbeat to avoid no authentication

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const path = require('path');
 const mongoose = require('mongoose');
-const awaitEvent = require('await-event');
+const awaitFirst = require('await-first');
 
 let count = 0;
 
@@ -76,10 +76,7 @@ function createOneClient(config, app) {
 
   app.beforeStart(function* () {
     app.coreLogger.info('[egg-mongoose] starting...');
-    yield Promise.race([
-      awaitEvent(db, 'connected'),
-      awaitEvent(db, 'error'),
-    ]);
+    yield awaitFirst(db, [ 'connected', 'error' ]);
     const index = count++;
     /*
      *remove heartbeat to avoid no authentication

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "egg-plugin"
   ],
   "dependencies": {
-    "await-event": "^2.0.0",
+    "await-first": "^1.0.0",
     "mongoose": "^4.8.6"
   },
   "devDependencies": {

--- a/test/mongoose.test.js
+++ b/test/mongoose.test.js
@@ -3,6 +3,8 @@
 const assert = require('assert');
 const request = require('supertest');
 const mm = require('egg-mock');
+const mongoose = require('mongoose');
+const EventEmitter = require('events');
 
 describe('test/mongoose.test.js', () => {
   describe('base', () => {
@@ -199,6 +201,57 @@ describe('test/mongoose.test.js', () => {
       assert(app.model.Book.prototype instanceof app.mongoose.Model);
       assert(app.model.book === undefined);
       assert(app.model.Other === undefined);
+    });
+  });
+
+  describe('throws on first connection', () => {
+    let app;
+    const createConnection = mongoose.createConnection;
+    let connection;
+    let onCreateConnection;
+    beforeEach(function* () {
+      connection = new EventEmitter();
+      mongoose.createConnection = () => {
+        setTimeout(onCreateConnection, 10);
+        return connection;
+      };
+    });
+
+    afterEach(function* () {
+      yield app.close();
+    });
+    afterEach(mm.restore);
+    afterEach(() => {
+      connection = null;
+      onCreateConnection = null;
+      mongoose.createConnection = createConnection;
+    });
+
+    it('should establish first connection', function* () {
+      app = mm.app({
+        baseDir: 'apps/mongoose',
+      });
+      onCreateConnection = () => {
+        connection.emit('connected');
+      };
+      yield app.ready();
+    });
+
+    it('should rethrow on first connection', function* () {
+      app = mm.app({
+        baseDir: 'apps/mongoose',
+      });
+      onCreateConnection = () => {
+        connection.emit('error', new Error('foobar'));
+      };
+      try {
+        yield app.ready();
+      } catch (err) {
+        assert(err != null);
+        assert(err.message === '[egg-mongoose]foobar');
+        return;
+      }
+      assert.fail('shall not succeeded');
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change

Referring to issue [No retries are made after "failed to connect on first connect"](https://github.com/Automattic/mongoose/issues/5169#issuecomment-304370617), errors on first connection shall be re-thrown so that egg will exit with the error in time.

Expect resolving [#2403](https://github.com/eggjs/egg/issues/2403)