### PR TITLE
update README to use await/async instead of generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,15 @@ module.exports = app => {
 }
 
 // {app_root}/app/controller/user.js
-exports.index = function* (ctx) {
-  ctx.body = yield ctx.model.User.find({});
+const Controller = require('egg').Controller;
+
+class UserController extends Controller {
+  async index() {
+    this.ctx.body = await this.ctx.model.User.find({}).exec();
+  }
 }
+
+module.exports = UserController;
 ```
 
 ## Multiple connections
@@ -131,14 +137,26 @@ module.exports = app => {
 }
 
 // app/controller/user.js
-exports.index = function* (ctx) {
-  ctx.body = yield ctx.model.User.find({}); // get data from db1
+const Controller = require('egg').Controller;
+
+class UserController extends Controller {
+  async index() {
+    this.ctx.body = await this.ctx.model.User.find({}).exec();
+  }
 }
 
+module.exports = UserController;
+
 // app/controller/book.js
-exports.index = function* (ctx) {
-  ctx.body = yield ctx.model.Book.find({}); // get data from db2
+const Controller = require('egg').Controller;
+
+class BookController extends Controller {
+  async index() {
+    this.ctx.body = await this.ctx.model.Book.find({}).exec();
+  }
 }
+
+module.exports = BookController;
 ```
 
 ### Default config


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
Hi 更新README里使用await/async，并且在执行查找操作时返回运行Query之后的数据，而不是Query Object：

```
    this.ctx.body = await this.ctx.model.User.find({}).exec();
```
