### PR TITLE
fix(typescript): types of mongoose should be dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "egg-plugin"
   ],
   "dependencies": {
+    "@types/mongoose": "^5.0.18",
     "await-first": "^1.0.0",
     "mongoose": "^5.0.17"
   },
   "devDependencies": {
-    "@types/mongoose": "^5.0.18",
     "autod": "^2.7.1",
     "bluebird": "^3.5.1",
     "dotenv": "^5.0.1",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->

typescript

##### Description of change
<!-- Provide a description of the change below this comment. -->

Types of mongoose should be dependencies instead of devDependencies, otherwise it won't work. (My mistake before)
