### PR TITLE
update dependencies mongoose version to support transactions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@types/mongoose": "^5.0.18",
     "await-first": "^1.0.0",
-    "mongoose": "^5.0.17"
+    "mongoose": "^5.2.0"
   },
   "devDependencies": {
     "autod": "^2.7.1",


### PR DESCRIPTION
Transactions are new in MongoDB 4.0 and Mongoose 5.2.0. 