### PR TITLE
chore: Add an arg in options for the update of mongodb to v4.X or above to avoid the warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '6'
-  - '7'
+  - '8'
+  - '10'
 install:
   - npm i npminstall && npminstall
 script:

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -50,6 +50,12 @@ function createOneClient(config, app) {
 
   assert(url, '[egg-mongoose] url is required on config');
 
+  // Notice we MUST add an option arg called `useNewUrlParser` and set to `true`
+  // in default, otherwises there'll be a warning since v4.X of mongodb.
+  // Ref: https://github.com/eggjs/egg/issues/3081
+  if (!options.hasOwnProperty('useNewUrlParser')) {
+    options.useNewUrlParser = true;
+  }
   app.coreLogger.info('[egg-mongoose] connecting %s', url);
 
   const db = mongoose.createConnection(url, options);

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
     "mongoose": "^5.0.17"
   },
   "devDependencies": {
+    "mocha": "^5.2.0",
     "autod": "^2.7.1",
     "bluebird": "^3.5.1",
     "dotenv": "^5.0.1",
     "egg": "^1.0.0-rc.3",
-    "egg-bin": "^2.4.0",
+    "egg-bin": "^4.9.0",
     "egg-mock": "^3.1.2",
     "eslint": "^3.17.1",
-    "eslint-config-egg": "^3.2.0",
+    "eslint-config-egg": "^7.1.0",
     "supertest": "^3.0.0",
     "webstorm-disable-index": "^1.1.2"
   },
@@ -50,7 +51,7 @@
     "lib"
   ],
   "ci": {
-    "version": "6, 7"
+    "version": "8, 10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since v4.X of mongodb we MUST add `useNewUrlParser` in `options`,
otherwises there'll be a warning to tell you that you should use
this arg.

Ref: https://github.com/eggjs/egg/issues/3081

- [x] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines
