### PR TITLE
fix: hide password for security

### DIFF
--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -56,7 +56,7 @@ function createOneClient(config, app) {
   if (!options.hasOwnProperty('useNewUrlParser')) {
     options.useNewUrlParser = true;
   }
-  app.coreLogger.info('[egg-mongoose] connecting %s', url);
+  app.coreLogger.info('[egg-mongoose] connecting %s', url.replace(/(?<=:)([^@:]+)(?=@[^@]+$)/, 'xxxxx'));
 
   const db = mongoose.createConnection(url, options);
 


### PR DESCRIPTION
The logger will print the password. That's not secure. This patch will hide it.

### Affected core subsystem(s)
`mongodb://root:pass@mongo:27017/admin` -> `mongodb://root:xxxxx@mongo:27017/admin`

### Description of change
filter the password before log it

![2019-02-22 5 07 55](https://user-images.githubusercontent.com/13268073/53232736-bb946580-36c6-11e9-9627-728fb9c06e50.png)

