### PR TITLE
fix(typescript): MongooseModels types

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+3.2.0 / 2019-05-16
+==================
+
+**features**
+  * [[`1f450fb`](http://github.com/eggjs/egg-mongoose/commit/1f450fb38acf4f04a63294a33e392c6f38830a88)] - feat: support mongoose global plugin (#35) (lkspc <<lkspc@qq.com>>)
+
 3.1.3 / 2019-05-06
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-mongoose",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "egg mongoose plugin",
   "eggPlugin": {
     "name": "mongoose"


### PR DESCRIPTION
After add a mongoose plugin , ctx.model can't read this plugin's extends function or property

eg:

import mongoosePaginate from 'mongoose-paginate-v2'
...
UserSchema.plugin(mongoosePaginate)
return mongoose.model('User', UserSchema)

ctx.model.User.paginate  can't read property 'pagination'

##### Checklist
- [x ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

type MongooseModels = {
    [key: string]: mongoose.Model<any>
  };

chang to:

type MongooseModels = {
    [key: string]: mongoose.Model
  };