### PR TITLE
feat: support putting the `model` files to the designated path and the customized delegate name to the `Context`  

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ exports.mongoose = {
 };
 // recommended
 exports.mongoose = {
+  //baseDir:'model', //models in `app/${model}`
+  //delegate:'model' //lood to `app[delegate]`
   client: {
     url: 'mongodb://127.0.0.1/example',
     options: {},

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  get model() {
-    return this.app.model;
-  },
-};

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -14,6 +14,6 @@ exports.mongoose = {
   loadModel: true,
   app: true,
   agent: false,
-  baseDir:'model', //models in `app/${model}`,the deafault is `app/model`
-  delegate:'model' //lood to `app[delegate]`,the deafault is app.model 
+  baseDir: 'model', // models in `app/${model}`,the deafault is `app/model`
+  delegate: 'model', // lood to `app[delegate]`,the deafault is app.model
 };

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -14,4 +14,6 @@ exports.mongoose = {
   loadModel: true,
   app: true,
   agent: false,
+  baseDir:'model',
+  delegate:'model'
 };

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -14,6 +14,6 @@ exports.mongoose = {
   loadModel: true,
   app: true,
   agent: false,
-  baseDir:'model',
-  delegate:'model'
+  baseDir:'model', //models in `app/${model}`,the deafault is `app/model`
+  delegate:'model' //lood to `app[delegate]`,the deafault is app.model 
 };

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -11,7 +11,7 @@ let count = 0;
 const globalPlugins = [];
 
 module.exports = app => {
-  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins, delegate} = app.config.mongoose;
+  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins, delegate } = app.config.mongoose;
 
   // compatibility
   if (!client && !clients && url) {
@@ -48,9 +48,9 @@ module.exports = app => {
 
   app.mongoose.loadModel = () => loadModelToApp(app);
 
-  let ctx = app.context;
+  const ctx = app.context;
   const DELEGATE = Symbol(`context#mongoose_${delegate}`);
-  Object.defineProperty(ctx,delegate,
+  Object.defineProperty(ctx, delegate,
     {
       get() {
         // context.model is different with app.model

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -11,7 +11,7 @@ let count = 0;
 const globalPlugins = [];
 
 module.exports = app => {
-  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins } = app.config.mongoose;
+  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins, delegate} = app.config.mongoose;
 
   // compatibility
   if (!client && !clients && url) {
@@ -48,6 +48,21 @@ module.exports = app => {
 
   app.mongoose.loadModel = () => loadModelToApp(app);
 
+  let ctx = app.context;
+  const DELEGATE = Symbol(`context#mongoose_${delegate}`);
+  Object.defineProperty(ctx,delegate,
+    {
+      get() {
+        // context.model is different with app.model
+        // so we can change the properties of ctx.model.xxx
+        if (!this[DELEGATE]) {
+          this[DELEGATE] = Object.create(app[delegate]);
+          this[DELEGATE].ctx = this;
+        }
+        return this[DELEGATE];
+      },
+      configurable: true,
+    });
   if (loadModel) {
     app.beforeStart(() => {
       loadModelToApp(app);
@@ -120,8 +135,9 @@ function createOneClient(config, app) {
 }
 
 function loadModelToApp(app) {
-  const dir = path.join(app.config.baseDir, 'app/model');
-  app.loader.loadToApp(dir, 'model', {
+  const config = app.config.mongoose;
+  const dir = path.join(app.config.baseDir, 'app', config.baseDir);
+  app.loader.loadToApp(dir, config.delegate, {
     inject: app,
     caseStyle: 'upper',
     filter(model) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review the below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
Don't affect the previous functions and config ways.

##### Description of change
<!-- Provide a description of the change below this comment. -->

###### The reason of why
Sometimes, the developers need to add multi and different databases(SQL and NoSQL) in one project. 
For my personal experience, I use MySQL as my defaulted database, the models of MySQL is placed on `app/model`. After the project is done for the period, I need to get the data from the company's MongoDB. However, both the defaulted path location `app/model` and delegate `ctx.model` in `Context` are used by the previous MySQL. I found the egg-mongoose don't support the features by the developers' needs. So I work on it and add the new features with the previous features and settings.

###### The new supported features 
- [x] support customizing the model folder path, the default is under `app/model`
- [x] support renaming the delegate in `Context`, the default is `app.model`