### PR TITLE
feat: Mongoose publishes its own types, so remove @types/mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "egg-plugin"
   ],
   "dependencies": {
-    "@types/mongoose": "^5.3.24",
     "await-first": "^1.0.0",
     "mongoose": "^5.10.9"
   },


### PR DESCRIPTION


#### Checklist

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

#### Affected core subsystem(s)



#### Description of change
Mongoose publishes its own types, so remove @types/mongoose.
