### PR TITLE
support two customized property for Database/通过自定义mongo的目录来支持同时挂载使用两种数据库

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ exports.mongoose = {
 };
 // recommended
 exports.mongoose = {
+  //baseDir:'model', //models in `app/${model}`
+  //delegate:'model' //lood to `app[delegate]`
   client: {
     url: 'mongodb://127.0.0.1/example',
     options: {},

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  get model() {
-    return this.app.model;
-  },
-};

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -14,6 +14,6 @@ exports.mongoose = {
   loadModel: true,
   app: true,
   agent: false,
-  baseDir:'model', //models in `app/${model}`,the deafault is `app/model`
-  delegate:'model' //lood to `app[delegate]`,the deafault is app.model 
+  baseDir: 'model', // models in `app/${model}`,the deafault is `app/model`
+  delegate: 'model', // lood to `app[delegate]`,the deafault is app.model
 };

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -14,4 +14,6 @@ exports.mongoose = {
   loadModel: true,
   app: true,
   agent: false,
+  baseDir:'model',
+  delegate:'model'
 };

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -14,6 +14,6 @@ exports.mongoose = {
   loadModel: true,
   app: true,
   agent: false,
-  baseDir:'model',
-  delegate:'model'
+  baseDir:'model', //models in `app/${model}`,the deafault is `app/model`
+  delegate:'model' //lood to `app[delegate]`,the deafault is app.model 
 };

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -11,7 +11,7 @@ let count = 0;
 const globalPlugins = [];
 
 module.exports = app => {
-  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins, delegate} = app.config.mongoose;
+  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins, delegate } = app.config.mongoose;
 
   // compatibility
   if (!client && !clients && url) {
@@ -48,9 +48,9 @@ module.exports = app => {
 
   app.mongoose.loadModel = () => loadModelToApp(app);
 
-  let ctx = app.context;
+  const ctx = app.context;
   const DELEGATE = Symbol(`context#mongoose_${delegate}`);
-  Object.defineProperty(ctx,delegate,
+  Object.defineProperty(ctx, delegate,
     {
       get() {
         // context.model is different with app.model

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -11,7 +11,7 @@ let count = 0;
 const globalPlugins = [];
 
 module.exports = app => {
-  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins } = app.config.mongoose;
+  const { client, clients, url, options, defaultDB, customPromise, loadModel, plugins, delegate} = app.config.mongoose;
 
   // compatibility
   if (!client && !clients && url) {
@@ -48,6 +48,21 @@ module.exports = app => {
 
   app.mongoose.loadModel = () => loadModelToApp(app);
 
+  let ctx = app.context;
+  const DELEGATE = Symbol(`context#mongoose_${delegate}`);
+  Object.defineProperty(ctx,delegate,
+    {
+      get() {
+        // context.model is different with app.model
+        // so we can change the properties of ctx.model.xxx
+        if (!this[DELEGATE]) {
+          this[DELEGATE] = Object.create(app[delegate]);
+          this[DELEGATE].ctx = this;
+        }
+        return this[DELEGATE];
+      },
+      configurable: true,
+    });
   if (loadModel) {
     app.beforeStart(() => {
       loadModelToApp(app);
@@ -120,8 +135,9 @@ function createOneClient(config, app) {
 }
 
 function loadModelToApp(app) {
-  const dir = path.join(app.config.baseDir, 'app/model');
-  app.loader.loadToApp(dir, 'model', {
+  const config = app.config.mongoose;
+  const dir = path.join(app.config.baseDir, 'app', config.baseDir);
+  app.loader.loadToApp(dir, config.delegate, {
     inject: app,
     caseStyle: 'upper',
     filter(model) {


### PR DESCRIPTION
support two customized properties for Database. For example, when we want to use MySQL and Mongo in the same project
通过自定义挂载目录，让出model的目录，以支持同时挂载使用两种数据库,比如我们想要在一个数据库中同时支持SQL和MySQl两种数据库


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines